### PR TITLE
Notificações

### DIFF
--- a/src/gui.pl
+++ b/src/gui.pl
@@ -50,6 +50,7 @@ startGui(Game) :-
     drawMenuBar(Display),
     drawBoard(Display, Game),
     drawPieces(Display),
+    drawInform('Valendo!!!'),
     send(Display, open).
 
 
@@ -84,7 +85,6 @@ drawInform(Message) :-
         ).
 
 
-
 drawBoard(Display, Game) :- draw(Display, 8, 8, 0, Game).
 
 
@@ -113,8 +113,8 @@ boxClickEvent(X, Y, Ref, Game) :-
     call(Game, X, Y, Turn, Ref).            % Call game to make the move
 
 
-changeTurn(white) :- retract(turn(_)), assert(turn(black)).
-changeTurn(black) :- retract(turn(_)), assert(turn(white)).
+changeTurn(white) :- retract(turn(_)), assert(turn(black)), drawInform('Turno das pretas!').
+changeTurn(black) :- retract(turn(_)), assert(turn(white)), drawInform('Turno das brancas!').
 
 
 selectBox(X, Y, Turn, Box) :-

--- a/src/gui.pl
+++ b/src/gui.pl
@@ -46,10 +46,23 @@ startGui(Game) :-
     new(@light, colour(@default, 60395, 60652, 53456)),
     new(@selected, colour(@default, 30840, 30840, 24672)),
     % Create and start the window
-    new(Display, window('Chess', size(800,800))),
+    new(Display, window('', size(800,800))),
+    drawMenuBar(Display),
     drawBoard(Display, Game),
     drawPieces(Display),
     send(Display, open).
+
+
+drawMenuBar(Display) :-
+    new(Frame, frame('Chess')),
+		send(Frame, append, new(Dialog, dialog('', size(800,30)))),
+        send(Dialog, display, new(@message, text(''))),
+        send(@message, center, Dialog?center),
+        send(Display, below, Dialog).
+
+
+drawMessage(Message) :-
+    send(@message, string, Message).
 
 
 drawBoard(Display, Game) :- draw(Display, 8, 8, 0, Game).

--- a/src/gui.pl
+++ b/src/gui.pl
@@ -54,15 +54,35 @@ startGui(Game) :-
 
 
 drawMenuBar(Display) :-
+    new(@orange, colour(orange)),
+    new(@red, colour(red)),
+    new(@blue, colour(blue)),
+    new(@purple, colour(@default, 32767, 0, 65535)),
     new(Frame, frame('Chess')),
-		send(Frame, append, new(Dialog, dialog('', size(800,30)))),
-        send(Dialog, display, new(@message, text(''))),
-        send(@message, center, Dialog?center),
-        send(Display, below, Dialog).
+		send(Frame, append, new(@menu_bar, dialog('', size(800,60)))),
+        send(@menu_bar, display, new(@message, text(''))),
+        send(@message, font, font(times, bold, 18)),
+        send(@message, center, @menu_bar?center),
+        send(Display, below, @menu_bar).
 
 
-drawMessage(Message) :-
-    send(@message, string, Message).
+drawWarning(Message) :-
+    send(@message, string, Message),
+    send(@message, center, @menu_bar?center),
+    (get(@message, colour, @red),
+        send(@message, colour, @orange);
+        send(@message, colour, @red)
+    ).
+
+
+drawInform(Message) :-
+    send(@message, string, Message),
+        send(@message, center, @menu_bar?center),
+        (get(@message, colour, @blue),
+            send(@message, colour, @purple);
+            send(@message, colour, @blue)
+        ).
+
 
 
 drawBoard(Display, Game) :- draw(Display, 8, 8, 0, Game).

--- a/src/main.pl
+++ b/src/main.pl
@@ -36,7 +36,7 @@ isCheckmate :-
     start_stockfish(Stockfish, Out),
     get_best_move(Stockfish, Out, Fen, 1, [Move|_]),
     Move == 40,
-    format('Checkmate, vitoria do jogador ~a\n', Turn).
+    drawWarning('Xequemate!').
 
 
 applyMove(1, [Sx, Sy, X, Y]) :-

--- a/src/stockfish.pl
+++ b/src/stockfish.pl
@@ -1,6 +1,3 @@
-:- consult(board).
-
-
 % start_stockfish/2 -> Cria pipes stdin e stdout para comunicação com o stockfish
 start_stockfish(Stockfish, Out) :-
     process_create(path(stockfish), [], [stdin(pipe(Stockfish)), stdout(pipe(Out))]).


### PR DESCRIPTION
Agora é possível gerar um notificação no topo da janela com `drawInform/1` e `drawWarning/1`, ambas alteram para uma variação de cor ao chamar duas vezes.

Por enquanto tem aviso de começo de jogo, xeque, xeque-mate e de quem é o turno.

Fica em aberto  as cores utilizadas ou mensagens exibidas, posso mudar... ou adicionar outras variações de mensagens....

Obs.: Tentei não usar acento nas mensagens...

![image](https://user-images.githubusercontent.com/30667234/182039994-bac32c91-2302-41a5-a458-80b7f1c1bc39.png)

